### PR TITLE
Created inner tile pointer for all 4 sides of a tile

### DIFF
--- a/Board.cpp
+++ b/Board.cpp
@@ -188,110 +188,110 @@ std::pair<int,int> Board::getOptimalPlacement(Tile &tile, std::vector< std::pair
 	return availableMoves[0];
 }
 
- int Board::positionPoints(int i, int j)
- {
- 	const int LAKE_POINTS = 6;
- 	const int JUNGLE_POINTS = 3;
- 	const int TRAIL_POINTS = 1;	
-	
- 	int points = 0;
- 	if (m_board[i + 1][j] != NULL)
- 	{
- 		points += animalPoints(i + 1, j);
- 		if (m_board[i + 1][j]->getUpFace()->getType() == "lake")
- 		{
- 			points += LAKE_POINTS;
- 		}
- 		else if (m_board[i + 1][j]->getUpFace()->getType() == "jungle")
- 		{
- 			points += JUNGLE_POINTS;
- 		}
- 		else if (m_board[i + 1][j]->getUpFace()->getType() == "trail")
- 		{
- 			points += TRAIL_POINTS;
- 		}
- 	}
- 	if (m_board[i - 1][j] != NULL)
- 	{
- 		points += animalPoints(i - 1, j);
- 		if (m_board[i - 1][j]->getDownFace()->getType() == "lake")
- 		{
- 			points += LAKE_POINTS;
- 		}
- 		else if (m_board[i - 1][j]->getDownFace()->getType() == "jungle")
- 		{
- 			points += JUNGLE_POINTS;
- 		}
- 		else if (m_board[i - 1][j]->getDownFace()->getType() == "trail")
- 		{
- 			points += TRAIL_POINTS;
- 		}
- 	}
- 	if (m_board[i][j + 1] != NULL)
- 	{
- 		points += animalPoints(i, j + 1);
- 		if (m_board[i][j + 1]->getLeftFace()->getType() == "lake")
- 		{
- 			points += LAKE_POINTS;
- 		}
- 		else if (m_board[i][j + 1]->getLeftFace()->getType() == "jungle")
- 		{
- 			points += JUNGLE_POINTS;
- 		}
- 		else if (m_board[i][j + 1]->getLeftFace()->getType() == "trail")
- 		{
- 			points += TRAIL_POINTS;
- 		}
- 	}
- 	if (m_board[i][j - 1] != NULL)
- 	{
- 		points += animalPoints(i, j - 1);
- 		if (m_board[i][j - 1]->getRightFace()->getType() == "lake")
- 		{
- 			points += LAKE_POINTS;
- 		}
- 		else if (m_board[i][j - 1]->getRightFace()->getType() == "jungle")
- 		{
- 			points += JUNGLE_POINTS;
- 		}
- 		else if (m_board[i][j - 1]->getRightFace()->getType() == "trail")
- 		{
- 			points += TRAIL_POINTS;
- 		}
- 	}
- 	return points;
- }
+int Board::positionPoints(int i, int j)
+{
+	const int LAKE_POINTS = 6;
+	const int JUNGLE_POINTS = 3;
+	const int TRAIL_POINTS = 1;	
 
- int Board::animalPoints(int i, int j)
- {
- 	const int DEN_POINTS = 10;
- 	const int DEER_POINTS = 2;
- 	const int BOAR_POINTS = 2;
- 	const int BUFFALO_POINTS = 2;
- 	const int CROCODILE_POINTS = -2;
- 	int points = 0;
- 	if (m_board[i][j]->getCenter().getType() == "Den")
- 	{
- 		points += DEN_POINTS;
- 	}
- 	if (m_board[i][j]->hasBoar())
- 	{
- 		points += BOAR_POINTS;
- 	}
- 	if (m_board[i][j]->hasBuffalo())
- 	{
- 		points += BUFFALO_POINTS;
- 	}
- 	if (m_board[i][j]->hasDeer())
- 	{
- 		points += DEER_POINTS;
- 	}
- 	if (m_board[i][j]->hasCrocodile())
- 	{
- 		points += CROCODILE_POINTS;
- 	}
- 	return points;
- }
+	int points = 0;
+	if (m_board[i + 1][j] != NULL)
+	{
+		points += animalPoints(i + 1, j);
+		if (m_board[i + 1][j]->getUpFace()->getType() == "lake")
+		{
+			points += LAKE_POINTS;
+		}
+		else if (m_board[i + 1][j]->getUpFace()->getType() == "jungle")
+		{
+			points += JUNGLE_POINTS;
+		}
+		else if (m_board[i + 1][j]->getUpFace()->getType() == "trail")
+		{
+			points += TRAIL_POINTS;
+		}
+	}
+	if (m_board[i - 1][j] != NULL)
+	{
+		points += animalPoints(i - 1, j);
+		if (m_board[i - 1][j]->getDownFace()->getType() == "lake")
+		{
+			points += LAKE_POINTS;
+		}
+		else if (m_board[i - 1][j]->getDownFace()->getType() == "jungle")
+		{
+			points += JUNGLE_POINTS;
+		}
+		else if (m_board[i - 1][j]->getDownFace()->getType() == "trail")
+		{
+			points += TRAIL_POINTS;
+		}
+	}
+	if (m_board[i][j + 1] != NULL)
+	{
+		points += animalPoints(i, j + 1);
+		if (m_board[i][j + 1]->getLeftFace()->getType() == "lake")
+		{
+			points += LAKE_POINTS;
+		}
+		else if (m_board[i][j + 1]->getLeftFace()->getType() == "jungle")
+		{
+			points += JUNGLE_POINTS;
+		}
+		else if (m_board[i][j + 1]->getLeftFace()->getType() == "trail")
+		{
+			points += TRAIL_POINTS;
+		}
+	}
+	if (m_board[i][j - 1] != NULL)
+	{
+		points += animalPoints(i, j - 1);
+		if (m_board[i][j - 1]->getRightFace()->getType() == "lake")
+		{
+			points += LAKE_POINTS;
+		}
+		else if (m_board[i][j - 1]->getRightFace()->getType() == "jungle")
+		{
+			points += JUNGLE_POINTS;
+		}
+		else if (m_board[i][j - 1]->getRightFace()->getType() == "trail")
+		{
+			points += TRAIL_POINTS;
+		}
+	}
+	return points;
+}
+
+int Board::animalPoints(int i, int j)
+{
+	const int DEN_POINTS = 10;
+	const int DEER_POINTS = 2;
+	const int BOAR_POINTS = 2;
+	const int BUFFALO_POINTS = 2;
+	const int CROCODILE_POINTS = -2;
+	int points = 0;
+	if (m_board[i][j]->getCenter().getType() == "Den")
+	{
+		points += DEN_POINTS;
+	}
+	if (m_board[i][j]->hasBoar())
+	{
+		points += BOAR_POINTS;
+	}
+	if (m_board[i][j]->hasBuffalo())
+	{
+		points += BUFFALO_POINTS;
+	}
+	if (m_board[i][j]->hasDeer())
+	{
+		points += DEER_POINTS;
+	}
+	if (m_board[i][j]->hasCrocodile())
+	{
+		points += CROCODILE_POINTS;
+	}
+	return points;
+}
 
 // Place a tile on the board. Make sure all neighboring tiles are pointing to the corresponding faces
 void Board::place_tile(std::pair<int, int> location, Tile &tile)
@@ -390,6 +390,16 @@ void Board::connectFaces(int row, int col)
 		(*m_board[row + 1][col]->getUpFace()).setNeighborFace(*m_board[row][col]->getDownFace());
 		(*m_board[row][col]->getDownFace()).setNeighborFace(*m_board[row + 1][col]->getUpFace());
 
+
+		// Set adjacent tiles now after setting faces
+		
+		// std::cout<<"**********DOWN TILE BEFORE SETTING IS "<<m_board[row][col]->getDownTile()<<std::endl;
+		(m_board[row][col])->setNeighborDownTile(*m_board[row + 1][col]);
+		// std::cout<<"**********DOWN TILE AFTER SETTING IS "<<m_board[row][col]->getDownTile()<<std::endl;
+		// std::cout<<"72 72 up tile before setting is "<<m_board[row+1][col]->getUpTile()<<std::endl;
+		(m_board[row+1][col])->setNeighborUpTile(*m_board[row][col]);
+		// std::cout<<"72 72 up tile after setting is "<<m_board[row+1][col]->getUpTile()<<std::endl;
+
 		//std::cout << "Neighbor of the up face of " << row + 1 << ' ' << col << " is " << m_board[row + 1][col]->getUpFace()->getNeighborFace() << std::endl;
 		//std::cout << "Neighbor of the down face of " << row << ' ' << col << " is " << m_board[row][col]->getDownFace()->getNeighborFace() << std::endl;
 	}
@@ -403,6 +413,10 @@ void Board::connectFaces(int row, int col)
 	{
 		(*m_board[row - 1][col]->getDownFace()).setNeighborFace(*m_board[row][col]->getUpFace());
 		(*m_board[row][col]->getUpFace()).setNeighborFace(*m_board[row - 1][col]->getDownFace());
+
+		// Set adjacent tiles now after setting faces
+		(m_board[row][col])->setNeighborUpTile(*m_board[row - 1][col]);
+		(m_board[row - 1][col])->setNeighborDownTile(*m_board[row][col]);
 
 		//std::cout << "Neighbor of the down face of " << row - 1 << ' ' << col << " is " << m_board[row - 1][col]->getDownFace()->getNeighborFace() << std::endl;
 		//std::cout << "Neighbor of the up face of " << row << ' ' << col << " is " << m_board[row][col]->getUpFace()->getNeighborFace() << std::endl;
@@ -418,6 +432,10 @@ void Board::connectFaces(int row, int col)
 		(*m_board[row][col - 1]->getRightFace()).setNeighborFace(*m_board[row][col]->getLeftFace());
 		(*m_board[row][col]->getLeftFace()).setNeighborFace(*m_board[row][col - 1]->getRightFace());
 
+		// Set adjacent tiles now after setting faces
+		(m_board[row][col])->setNeighborLeftTile(*m_board[row][col - 1]);
+		(m_board[row][col - 1])->setNeighborRightTile(*m_board[row][col]);
+
 		//std::cout << "Neighbor of the right face of " << row << ' ' << col - 1 << " is " << m_board[row][col - 1]->getRightFace()->getNeighborFace() << std::endl;
 		//std::cout << "Neighbor of the left face of " << row << ' ' << col << " is " << m_board[row][col]->getLeftFace()->getNeighborFace() << std::endl;
 	}
@@ -431,6 +449,10 @@ void Board::connectFaces(int row, int col)
 	{
 		(*m_board[row][col + 1]->getLeftFace()).setNeighborFace(*m_board[row][col]->getRightFace());
 		(*m_board[row][col]->getRightFace()).setNeighborFace(*m_board[row][col + 1]->getLeftFace());
+
+		// Set adjacent tiles now after setting faces
+		(m_board[row][col])->setNeighborRightTile(*m_board[row][col + 1]);
+		(m_board[row][col + 1])->setNeighborLeftTile(*m_board[row][col]);
 
 		//std::cout << "Neighbor of the left face of " << row << ' ' << col + 1 << " is " << m_board[row][col + 1]->getLeftFace()->getNeighborFace() << std::endl;
 		//std::cout << "Neighbor of the right face of " << row << ' ' << col << " is " << m_board[row][col]->getRightFace()->getNeighborFace() << std::endl;

--- a/Board.cpp
+++ b/Board.cpp
@@ -433,12 +433,13 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 Structure Board::checkTrail(Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int, int> blockSpot)
 {
 	Structure trailStruct("trail", blockSpot);
-	buildTrail(&trailStruct, tile, tileBlocks, blockSpot);
+	std::vector<Tile*> visitedTiles;
+	visitedTiles.push_back(tile);
+	buildTrail(&trailStruct, tile, tileBlocks, blockSpot, visitedTiles);
 	return trailStruct;
 }
 
-void Board::buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot) {
-	// std::cout<<"in build lake"<<std::endl;
+void Board::buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot, std::vector<Tile*> &visitedTiles) {
 	int row = blockSpot.first;
 	int col = blockSpot.second;
 	tileBlocks[row][col].visit();
@@ -461,36 +462,68 @@ void Board::buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Bl
 	// Check tiles above, below, left, and right of the current block to see if lake structure continues
 	// std::cout<<"about to cehck row+1"<<std::endl;
 	if((row + 1) <= 2 && !(tileBlocks[row + 1][col].isVisited()) && tileBlocks[row+1][col].getType() == "trail") {
-		// std::cout<<"passing row+1"<<std::endl;
-		buildTrail(struc, tile, tileBlocks, std::pair<int,int>(row+1,col));
+		buildTrail(struc, tile, tileBlocks, std::pair<int,int>(row+1,col), visitedTiles);
 	}
 	else if(row + 1 > 2 && tile->getDownTile() != NULL) {
-		buildTrail(struc, tile->getDownTile(), tileBlocks, std::pair<int,int>(row - 2,col));
+		bool visitedNeighborTile = false;
+		for(int i = 0; i < visitedTiles.size(); i++) {
+			if(visitedTiles[i] == tile->getDownTile())
+				visitedNeighborTile = true;
+		}
+		if(!visitedNeighborTile) {
+			visitedTiles.push_back(tile->getDownTile());
+			tileBlocks = tile->getDownTile()->getInnerBlocks();
+			buildTrail(struc, tile->getDownTile(), tileBlocks, std::pair<int,int>(row - 2,col), visitedTiles);
+		}
 	}
 	// std::cout<<"about to check row-1"<<std::endl;
 	if((row - 1) >= 0 && !(tileBlocks[row - 1][col].isVisited()) && tileBlocks[row - 1][col].getType() == "trail") {
-		// std::cout<<"passing row-1"<<std::endl;
-		buildTrail(struc, tile, tileBlocks, std::pair<int,int>(row-1,col));
+		buildTrail(struc, tile, tileBlocks, std::pair<int,int>(row-1,col), visitedTiles);
 	}
 	else if(row-1 < 0 && tile->getUpTile() != NULL) {
-		buildTrail(struc, tile->getUpTile(), tileBlocks, std::pair<int,int>(row+2,col));
+		bool visitedNeighborTile = false;
+		for(int i = 0; i < visitedTiles.size(); i++) {
+			if(visitedTiles[i] == tile->getUpTile())
+				visitedNeighborTile = true;
+		}
+		if(!visitedNeighborTile) {
+			visitedTiles.push_back(tile->getUpTile());
+			tileBlocks = tile->getUpTile()->getInnerBlocks();
+			buildTrail(struc, tile->getUpTile(), tileBlocks, std::pair<int,int>(row+2,col), visitedTiles);
+		}
 	}
 	// std::cout<<"about to check col+1"<<std::endl;
 	if((col + 1) <= 2 && !(tileBlocks[row][col + 1].isVisited()) && tileBlocks[row][col + 1].getType() == "trail") {
-		// std::cout<<"passing col+1"<<std::endl;
-		buildTrail(struc, tile, tileBlocks, std::pair<int,int>(row,col+1));
+		buildTrail(struc, tile, tileBlocks, std::pair<int,int>(row,col+1), visitedTiles);
 	}
 	else if(col+1 > 2 && tile->getRightTile() != NULL) {
-		buildTrail(struc, tile->getRightTile(), tileBlocks, std::pair<int,int>(row,col-2));
+		bool visitedNeighborTile = false;
+		for(int i = 0; i < visitedTiles.size(); i++) {
+			if(visitedTiles[i] == tile->getRightTile())
+				visitedNeighborTile = true;
+		}
+		if(!visitedNeighborTile) {
+			visitedTiles.push_back(tile->getRightTile());
+			tileBlocks = tile->getRightTile()->getInnerBlocks();
+			buildTrail(struc, tile->getRightTile(), tileBlocks, std::pair<int,int>(row,col-2), visitedTiles);
+		}
 	}
 	// std::cout<<"about to check col-1"<<std::endl;
 	if((col - 1) >= 0 && !(tileBlocks[row][col-1].isVisited()) && tileBlocks[row][col - 1].getType() == "trail") {
 		// std::cout<<"passing col-1"<<std::endl;
-		buildTrail(struc, tile, tileBlocks, std::pair<int,int>(row,col-1));
+		buildTrail(struc, tile, tileBlocks, std::pair<int,int>(row,col-1), visitedTiles);
 	} 
 	else if(col-1 < 0 && tile->getLeftTile() != NULL) {
-		std::cout<<"passed getLeft tile, should be going to 72, 72"<<std::endl;
-		buildTrail(struc, tile->getLeftTile(), tileBlocks, std::pair<int,int>(row,col+2));
+		bool visitedNeighborTile = false;
+		for(int i = 0; i < visitedTiles.size(); i++) {
+			if(visitedTiles[i] == tile->getLeftTile())
+				visitedNeighborTile = true;
+		}
+		if(!visitedNeighborTile) {
+			visitedTiles.push_back(tile->getLeftTile());
+			tileBlocks = tile->getLeftTile()->getInnerBlocks();
+			buildTrail(struc, tile->getLeftTile(), tileBlocks, std::pair<int,int>(row,col+2), visitedTiles);
+		}
 	}
 	return;
 }

--- a/Board.cpp
+++ b/Board.cpp
@@ -330,6 +330,11 @@ the problem there is how to remember which tiles youve already visited and which
 // 	Structure jungleStruct("jungle", blockSpot);
 // }
 
+void Board::placeMeeple(int i, int j, std::pair<int, int> location)
+{
+	m_board[i][j]->placeMeeple(location);
+}
+
 Structure Board::checkLake(Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int, int> blockSpot)
 {
 	std::cout<<"in check lake"<<std::endl;

--- a/Board.cpp
+++ b/Board.cpp
@@ -301,7 +301,7 @@ void Board::place_tile(std::pair<int, int> location, Tile &tile)
 
 	m_board[row][col] = &tile;
 	connectFaces(row, col);
-	getStructures(row, col);
+	std::vector<Structure> availableStructures = getStructures(row, col);
 }
 
 // bool Board::checkMeeplePlacement(Tile tile, std::pair<int,int> blockSpot)
@@ -344,6 +344,7 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 	// std::cout<<"in build lake"<<std::endl;
 	int row = blockSpot.first;
 	int col = blockSpot.second;
+	std::cout<<"in build lake at "<<row<<' '<<col<<std::endl;
 	tileBlocks[row][col].visit();
 	// for(int i = 0; i < 3; i++) {
 	// 	for(int j = 0; j < 3; j++) {
@@ -367,6 +368,7 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 		buildLake(struc, tile, tileBlocks, std::pair<int,int>(row+1,col), visitedTiles);
 	}
 	else if(row + 1 > 2 && tile->getDownTile() != NULL) {
+		row = 0;
 		bool visitedNeighborTile = false;
 		for(int i = 0; i < visitedTiles.size(); i++) {
 			if(visitedTiles[i] == tile->getDownTile())
@@ -374,8 +376,8 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 		}
 		if(!visitedNeighborTile) {
 			visitedTiles.push_back(tile->getDownTile());
-			tileBlocks = tile->getDownTile()->getInnerBlocks();
-			buildLake(struc, tile->getDownTile(), tileBlocks, std::pair<int,int>(row - 2,col), visitedTiles);
+			std::vector< std::vector<Block> > newBlocks = tile->getDownTile()->getInnerBlocks();
+			buildLake(struc, tile->getDownTile(), newBlocks, std::pair<int,int>(row,col), visitedTiles);
 		}
 	}
 	// std::cout<<"about to check row-1"<<std::endl;
@@ -383,6 +385,7 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 		buildLake(struc, tile, tileBlocks, std::pair<int,int>(row-1,col), visitedTiles);
 	}
 	else if(row-1 < 0 && tile->getUpTile() != NULL) {
+		row = 2;
 		bool visitedNeighborTile = false;
 		for(int i = 0; i < visitedTiles.size(); i++) {
 			if(visitedTiles[i] == tile->getUpTile())
@@ -390,8 +393,8 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 		}
 		if(!visitedNeighborTile) {
 			visitedTiles.push_back(tile->getUpTile());
-			tileBlocks = tile->getUpTile()->getInnerBlocks();
-			buildLake(struc, tile->getUpTile(), tileBlocks, std::pair<int,int>(row+2,col), visitedTiles);
+			std::vector< std::vector<Block> > newBlocks = tile->getUpTile()->getInnerBlocks();
+			buildLake(struc, tile->getUpTile(), newBlocks, std::pair<int,int>(row,col), visitedTiles);
 		}
 	}
 	// std::cout<<"about to check col+1"<<std::endl;
@@ -399,6 +402,7 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 		buildLake(struc, tile, tileBlocks, std::pair<int,int>(row,col+1), visitedTiles);
 	}
 	else if(col+1 > 2 && tile->getRightTile() != NULL) {
+		col = 0;
 		bool visitedNeighborTile = false;
 		for(int i = 0; i < visitedTiles.size(); i++) {
 			if(visitedTiles[i] == tile->getRightTile())
@@ -406,8 +410,8 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 		}
 		if(!visitedNeighborTile) {
 			visitedTiles.push_back(tile->getRightTile());
-			tileBlocks = tile->getRightTile()->getInnerBlocks();
-			buildLake(struc, tile->getRightTile(), tileBlocks, std::pair<int,int>(row,col-2), visitedTiles);
+			std::vector< std::vector<Block> > newBlocks = tile->getRightTile()->getInnerBlocks();
+			buildLake(struc, tile->getRightTile(), newBlocks, std::pair<int,int>(row,col), visitedTiles);
 		}
 	}
 	// std::cout<<"about to check col-1"<<std::endl;
@@ -416,6 +420,7 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 		buildLake(struc, tile, tileBlocks, std::pair<int,int>(row,col-1), visitedTiles);
 	} 
 	else if(col-1 < 0 && tile->getLeftTile() != NULL) {
+		col = 2;
 		bool visitedNeighborTile = false;
 		for(int i = 0; i < visitedTiles.size(); i++) {
 			if(visitedTiles[i] == tile->getLeftTile())
@@ -423,8 +428,8 @@ void Board::buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Blo
 		}
 		if(!visitedNeighborTile) {
 			visitedTiles.push_back(tile->getLeftTile());
-			tileBlocks = tile->getLeftTile()->getInnerBlocks();
-			buildLake(struc, tile->getLeftTile(), tileBlocks, std::pair<int,int>(row,col+2), visitedTiles);
+			std::vector< std::vector<Block> > newBlocks = tile->getLeftTile()->getInnerBlocks();
+			buildLake(struc, tile->getLeftTile(), newBlocks, std::pair<int,int>(row,col), visitedTiles);
 		}
 	}
 	return;
@@ -472,8 +477,8 @@ void Board::buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Bl
 		}
 		if(!visitedNeighborTile) {
 			visitedTiles.push_back(tile->getDownTile());
-			tileBlocks = tile->getDownTile()->getInnerBlocks();
-			buildTrail(struc, tile->getDownTile(), tileBlocks, std::pair<int,int>(row - 2,col), visitedTiles);
+			std::vector< std::vector<Block> > newBlocks = tile->getDownTile()->getInnerBlocks();
+			buildTrail(struc, tile->getDownTile(), newBlocks, std::pair<int,int>(row - 2,col), visitedTiles);
 		}
 	}
 	// std::cout<<"about to check row-1"<<std::endl;
@@ -488,8 +493,8 @@ void Board::buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Bl
 		}
 		if(!visitedNeighborTile) {
 			visitedTiles.push_back(tile->getUpTile());
-			tileBlocks = tile->getUpTile()->getInnerBlocks();
-			buildTrail(struc, tile->getUpTile(), tileBlocks, std::pair<int,int>(row+2,col), visitedTiles);
+			std::vector< std::vector<Block> > newBlocks = tile->getUpTile()->getInnerBlocks();
+			buildTrail(struc, tile->getUpTile(), newBlocks, std::pair<int,int>(row+2,col), visitedTiles);
 		}
 	}
 	// std::cout<<"about to check col+1"<<std::endl;
@@ -504,8 +509,8 @@ void Board::buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Bl
 		}
 		if(!visitedNeighborTile) {
 			visitedTiles.push_back(tile->getRightTile());
-			tileBlocks = tile->getRightTile()->getInnerBlocks();
-			buildTrail(struc, tile->getRightTile(), tileBlocks, std::pair<int,int>(row,col-2), visitedTiles);
+			std::vector< std::vector<Block> > newBlocks = tile->getRightTile()->getInnerBlocks();
+			buildTrail(struc, tile->getRightTile(), newBlocks, std::pair<int,int>(row,col-2), visitedTiles);
 		}
 	}
 	// std::cout<<"about to check col-1"<<std::endl;
@@ -521,8 +526,8 @@ void Board::buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Bl
 		}
 		if(!visitedNeighborTile) {
 			visitedTiles.push_back(tile->getLeftTile());
-			tileBlocks = tile->getLeftTile()->getInnerBlocks();
-			buildTrail(struc, tile->getLeftTile(), tileBlocks, std::pair<int,int>(row,col+2), visitedTiles);
+			std::vector< std::vector<Block> > newBlocks = tile->getLeftTile()->getInnerBlocks();
+			buildTrail(struc, tile->getLeftTile(), newBlocks, std::pair<int,int>(row,col+2), visitedTiles);
 		}
 	}
 	return;
@@ -611,13 +616,13 @@ void Board::connectFaces(int row, int col)
 
 // Pass in the coordinates of the tile that you just placed
 std::vector<Structure> Board::getStructures(int row, int col) {
+	std::cout<<"IN GET STRUCTURES FOR "<<row<<' '<<col<<std::endl;
 	std::vector<Structure> structures;
 	Tile* tile = m_board[row][col];
 	std::vector< std::vector<Block> > tileBlocks = tile->getInnerBlocks();
 	for(int i = 0; i < 3; i++) {
 		for(int j = 0; j < 3; j++) {
 			if(!(tileBlocks[i][j].isVisited())) {
-				std::cout<<"past first visit check"<<std::endl;
 				if(tileBlocks[i][j].getType() == "jungle" || tileBlocks[i][j].getType() == "mixed") {
 					// Structure struc = checkJungle(tile, std::pair<int,int>(i,j));
 					// structures.push_back(struc);
@@ -625,7 +630,6 @@ std::vector<Structure> Board::getStructures(int row, int col) {
 				else if(tileBlocks[i][j].getType() == "lake") {
 					Structure struc = checkLake(tile, tileBlocks, std::pair<int,int>(i,j));
 					structures.push_back(struc);
-					
 				}
 				else if(tileBlocks[i][j].getType() == "trail") {
 					Structure struc = checkTrail(tile, tileBlocks, std::pair<int,int>(i,j));
@@ -640,7 +644,8 @@ std::vector<Structure> Board::getStructures(int row, int col) {
 		}
 	}
 	for(int i = 0; i < structures.size(); i++) {
-		std::cout<<"Structure is of type "<<structures[i].type<<" with "<<structures[i].structureBlocks.size()<<" blocks."<<std::endl;
+		std::cout<<"Structure is of type "<<structures[i].type<<" with "<<structures[i].structureBlocks.size()
+		<<" blocks and starting block at "<<structures[i].startingBlock.first<<' '<<structures[i].startingBlock.second<<std::endl;
 	}
 	std::cout<<"Structures size is "<<structures.size()<<std::endl;
 	return structures;

--- a/Board.h
+++ b/Board.h
@@ -41,6 +41,8 @@ public:
 	
 	// See if feature tile is being placed in has a meeple
 	bool checkMeeplePlacement(Tile tile, std::pair<int, int> blockSpot);
+	void placeMeeple(int i, int j, std::pair<int,int> location);
+	void meepleAi(int i, int j);
 
 	// Helper functions for building the structures of a recently placed tile
 	void buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot, std::vector<Tile*> &visitedTiles);

--- a/Board.h
+++ b/Board.h
@@ -44,7 +44,7 @@ public:
 
 	// Helper functions for building the structures of a recently placed tile
 	void buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot, std::vector<Tile*> &visitedTiles);
-	void buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot);
+	void buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot, std::vector<Tile*> &visitedTiles);
 	void buildJungle(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot);
 
 private:

--- a/Board.h
+++ b/Board.h
@@ -2,6 +2,7 @@
 #define BOARD_H
 
 #include "Tile_Structure/Tile.h"
+#include "Tile_Structure/Structure.h"
 #include <vector>
 #include <string>
 #include <iostream>
@@ -33,14 +34,20 @@ public:
 
 	// places the tile on the board and connects the faces
 	void place_tile(std::pair<int, int> location, Tile &tile);
+
+	// Get a vector of the structures (and coordinates) within the tile where you may place a meeple
+	// Pass in the coordinates of the recently placed tile to access it within the board
+	std::vector<Structure> getStructures(int row, int col);
 	
 	// See if feature tile is being placed in has a meeple
 	bool checkMeeplePlacement(Tile tile, std::pair<int, int> blockSpot);
 
+	void buildLake(Structure* struc, Tile *tile, std::pair<int,int> blockSpot);
+
 private:
-	bool checkJungle(Tile tile, std::pair<int, int> blockSpot);
-	bool checkLake(Tile tile, std::pair<int, int> blockSpot);
-	bool checkTrail(Tile tile, std::pair<int, int> blockSpot);
+	Structure checkJungle(Tile *tile, std::pair<int, int> blockSpot);
+	Structure checkLake(Tile *tile, std::pair<int, int> blockSpot);
+	Structure checkTrail(Tile *tile, std::pair<int, int> blockSpot);
 
 	void connectFaces(int row, int col);
 

--- a/Board.h
+++ b/Board.h
@@ -42,12 +42,15 @@ public:
 	// See if feature tile is being placed in has a meeple
 	bool checkMeeplePlacement(Tile tile, std::pair<int, int> blockSpot);
 
-	void buildLake(Structure* struc, Tile *tile, std::pair<int,int> blockSpot);
+	// Helper functions for building the structures of a recently placed tile
+	void buildLake(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot, std::vector<Tile*> &visitedTiles);
+	void buildTrail(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot);
+	void buildJungle(Structure* struc, Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int,int> blockSpot);
 
 private:
-	Structure checkJungle(Tile *tile, std::pair<int, int> blockSpot);
-	Structure checkLake(Tile *tile, std::pair<int, int> blockSpot);
-	Structure checkTrail(Tile *tile, std::pair<int, int> blockSpot);
+	// Structure checkJungle(Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int, int> blockSpot);
+	Structure checkLake(Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int, int> blockSpot);
+	Structure checkTrail(Tile *tile, std::vector< std::vector<Block> >& tileBlocks, std::pair<int, int> blockSpot);
 
 	void connectFaces(int row, int col);
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -91,11 +91,19 @@ void Game::meepleAi(int i, int j)
 		return;
 	}
 	std::vector<Structure> structures = gameboard.getStructures(i, j);
-	if (structures.size() > 0 && !structures[0].hasMeeple)
+	if (structures.size() > 0)
 	{
 		int mostPoints = 0;
-		int bestStruct = 0;
+		int bestStruct = -1;
 		for (size_t ii = 0; ii < structures.size(); ii++)
+		{
+			if (!structures[ii].hasMeeple)
+			{
+				bestStruct = ii;
+			}
+		}
+		
+		for (size_t ii = bestStruct; ii < structures.size(); ii++)
 		{
 			if (!structures[ii].hasMeeple)
 			{
@@ -107,7 +115,7 @@ void Game::meepleAi(int i, int j)
 				}
 			}
 		}
-		gameboard.placeMeeple(i, j, structures[bestStruct].startingBlock);
+		if(bestStruct != -1) gameboard.placeMeeple(i, j, structures[bestStruct].startingBlock);
 	}
 }
 

--- a/Game.cpp
+++ b/Game.cpp
@@ -91,17 +91,20 @@ void Game::meepleAi(int i, int j)
 		return;
 	}
 	std::vector<Structure> structures = gameboard.getStructures(i, j);
-	if (structures.size() > 0)
+	if (structures.size() > 0 && !structures[0].hasMeeple)
 	{
 		int mostPoints = 0;
 		int bestStruct = 0;
 		for (size_t ii = 0; ii < structures.size(); ii++)
 		{
-			int points = structurePoints(structures[ii]);
-			if (points > mostPoints)
+			if (!structures[ii].hasMeeple)
 			{
-				mostPoints = points;
-				bestStruct = ii;
+				int points = structurePoints(structures[ii]);
+				if (points > mostPoints)
+				{
+					mostPoints = points;
+					bestStruct = ii;
+				}
 			}
 		}
 		gameboard.placeMeeple(i, j, structures[bestStruct].startingBlock);

--- a/Game.cpp
+++ b/Game.cpp
@@ -1,5 +1,6 @@
 #include "Game.h"
 #include "Board.h"
+#include "Tile_Structure/Structure.h"
 #include <fstream>
 #include <iostream>
 
@@ -79,6 +80,75 @@ void Game::makeMove(Tile tile) {
 	}
 	else {
 		std::cout << "TILE " << tile.getType() << " CANNOT BE PLACED" << std::endl;
+	}
+}
+
+void Game::meepleAi(int i, int j)
+{
+	if (gameboard.m_board[i][j]->getCenter().getType() == "den")
+	{
+		gameboard.placeMeeple(i, j, std::pair<int,int> (1,1));
+		return;
+	}
+	std::vector<Structure> structures = gameboard.getStructures(i, j);
+	if (structures.size() > 0)
+	{
+		int mostPoints = 0;
+		int bestStruct = 0;
+		for (size_t ii = 0; ii < structures.size(); ii++)
+		{
+			int points = structurePoints(structures[ii]);
+			if (points > mostPoints)
+			{
+				mostPoints = points;
+				bestStruct = ii;
+			}
+		}
+		gameboard.placeMeeple(i, j, structures[bestStruct].startingBlock);
+	}
+}
+
+int Game::structurePoints(Structure structure)
+{
+	int points = 0;
+	const int SIZE_POINTS = 1;
+	const int JUNGLE_POINTS = 3;
+	const int LAKE_POINTS = 2;
+	const int TRAIL_POINTS = 1;
+	const int PREY_POINTS = 1;
+	const int CROC_POINTS = -2;
+	
+	for (size_t i = 0; i < structure.structureBlocks.size(); i++)
+	{
+		points += SIZE_POINTS;
+	}
+	if (structure.type == "jungle")
+	{
+		points += JUNGLE_POINTS;
+	}
+	if (structure.type == "lake")
+	{
+		points += LAKE_POINTS;
+	}
+	if (structure.type == "trail")
+	{
+		points += TRAIL_POINTS;
+	}
+	for (int i = 0; i < structure.boarCount; i++)
+	{
+		points += PREY_POINTS;
+	}
+	for (int i = 0; i < structure.deerCount; i++)
+	{
+		points += PREY_POINTS;
+	}
+	for (int i = 0; i < structure.buffaloCount; i++)
+	{
+		points += PREY_POINTS;
+	}
+	for (int i = 0; i < structure.crocodileCount; i++)
+	{
+		points += CROC_POINTS;
 	}
 }
 

--- a/Game.h
+++ b/Game.h
@@ -13,6 +13,7 @@ public:
 
 	void play();
 	void makeMove(Tile);
+	void meepleAi(int i, int j);
 	void updateBoard();
 	void switchPlayer();
 	void printToTextFile(Board);
@@ -20,6 +21,8 @@ public:
 
 	Board gameboard;
 private:
+	int structurePoints(Structure structure);
+
 	std::string gameId;
 	Player player1;
 	Player player2;

--- a/Tile_Structure/Block.cpp
+++ b/Tile_Structure/Block.cpp
@@ -14,6 +14,7 @@ Block::Block(char c)
 	  type = "mixed";
   else
   	type = "";
+  visited = false;
 }
 
 Block::Block()

--- a/Tile_Structure/Block.cpp
+++ b/Tile_Structure/Block.cpp
@@ -11,7 +11,7 @@ Block::Block(char c)
   else if (c == Den)
 	  type = "den";
   else if (c == Mixed)
-	  type == "mixed";
+	  type = "mixed";
   else
   	type = "";
 }
@@ -36,7 +36,7 @@ void Block::setType(char c) {
   else if (c == Den)
     type = "den";
   else if (c == Mixed)
-	  type == "mixed";
+	  type = "mixed";
 }
 
 void Block::placeMeeple() {

--- a/Tile_Structure/Block.h
+++ b/Tile_Structure/Block.h
@@ -17,8 +17,13 @@ public:
 	Block();
 	~Block();
 
+	bool isVisited() { return visited; }
+	void visit() { visited = true; }
+	void unVisit() { visited = false; }
+
 	std::string getType() { return type; }
 	void setType(char type);
+
 	void placeMeeple();
 	bool hasMeeple() { return meeple; }
 

--- a/Tile_Structure/Structure.cpp
+++ b/Tile_Structure/Structure.cpp
@@ -1,0 +1,20 @@
+#include "Structure.h"
+
+#include <string>
+
+Structure::Structure(std::string type, std::pair<int,int> blockCoords) {
+	this->type = type;
+	this->startingBlock = blockCoords;
+}
+
+Structure::Structure(std::string type) {
+	this->type = type;
+}
+
+Structure::Structure() {
+
+}
+
+Structure::~Structure() {
+
+}

--- a/Tile_Structure/Structure.h
+++ b/Tile_Structure/Structure.h
@@ -1,0 +1,30 @@
+#ifndef STRUCTURE_H
+#define STRUCTURE_H
+
+#include "Block.h"
+#include <string>
+
+class Structure {
+public:
+	Structure(std::string type, std::pair<int,int> blockCoords);
+	Structure(std::string type);
+	Structure();
+	~Structure();
+
+	std::string type;
+
+	// Get the lowest block coordinates within the recently placed tile where this structure begins
+	std::pair<int,int> startingBlock;
+
+	// Vector of the blocks that this structure is composed of (need to set all to unvisited after we compose structure)
+	std::vector<Block> structureBlocks;
+
+	// Keep variables to track the number of game animals as well as prey animals within each structure
+	int boarCount;
+	int deerCount;
+	int buffaloCount;
+
+	int crocodileCount;
+};
+
+#endif

--- a/Tile_Structure/Structure.h
+++ b/Tile_Structure/Structure.h
@@ -24,6 +24,8 @@ public:
 	int deerCount;
 	int buffaloCount;
 
+	bool hasMeeple = false;
+
 	int crocodileCount;
 };
 

--- a/Tile_Structure/Tile.cpp
+++ b/Tile_Structure/Tile.cpp
@@ -457,10 +457,10 @@ Tile::~Tile()
 }
 
 void Tile::setFaceTypes() {
-  up.setType(innerBlocks[0][1].getType());
-  down.setType(innerBlocks[2][1].getType());
-  left.setType(innerBlocks[1][0].getType());
-  right.setType(innerBlocks[1][2].getType());
+  upFace.setType(innerBlocks[0][1].getType());
+  downFace.setType(innerBlocks[2][1].getType());
+  leftFace.setType(innerBlocks[1][0].getType());
+  rightFace.setType(innerBlocks[1][2].getType());
 }
 
 void Tile::setRow(int row, char type1, char type2, char type3) {
@@ -478,21 +478,21 @@ void Tile::rotate()
   innerBlocks[0][1] = Block(unrotated[1][2]);
   innerBlocks[0][2] = Block(unrotated[2][2]);
 
-  this->up.setType(innerBlocks[0][1].getType());
+  this->upFace.setType(innerBlocks[0][1].getType());
 
   // Middle row except center block (doesn't rotate)
   innerBlocks[1][0] = Block(unrotated[0][1]);
   innerBlocks[1][2] = Block(unrotated[2][1]);
 
-  this->left.setType(innerBlocks[1][0].getType());
-  this->right.setType(innerBlocks[1][2].getType());
+  this->leftFace.setType(innerBlocks[1][0].getType());
+  this->rightFace.setType(innerBlocks[1][2].getType());
 
   // Bottom row
   innerBlocks[2][0] = Block(unrotated[0][0]);
   innerBlocks[2][1] = Block(unrotated[1][0]);
   innerBlocks[2][2] = Block(unrotated[2][0]);
 
-  this->down.setType(innerBlocks[2][1].getType());
+  this->downFace.setType(innerBlocks[2][1].getType());
 
 
 
@@ -502,10 +502,23 @@ void Tile::rotate()
     rotation = 0;
 }
 
+void Tile::setNeighborUpTile(Tile &tile) {
+  upTile = &tile;
+}
+void Tile::setNeighborDownTile(Tile &tile) {
+  downTile = &tile;
+}
+void Tile::setNeighborLeftTile(Tile &tile) {
+  leftTile = &tile;
+}
+void Tile::setNeighborRightTile(Tile &tile) {
+  rightTile = &tile;
+}
+
 // Method to check if tile has any open face (up, down, left, right)
 bool Tile::hasOpenFace()
 {
-	if(!up.connected() || !down.connected() || !left.connected() || !right.connected())
+	if(!upFace.connected() || !downFace.connected() || !leftFace.connected() || !rightFace.connected())
     return true;
 	else 
     return false;
@@ -514,13 +527,13 @@ bool Tile::hasOpenFace()
 std::vector<std::string> Tile::getOpenFaces()
 {
 	std::vector<std::string> openFaces;
-	if(!up.connected())
+	if(!upFace.connected())
 		openFaces.push_back("up");
-	if(!down.connected())
+	if(!downFace.connected())
 		openFaces.push_back("down");
-	if(!left.connected())
+	if(!leftFace.connected())
 		openFaces.push_back("left");
-	if(!right.connected())
+	if(!rightFace.connected())
 		openFaces.push_back("right");
 	return openFaces;
 }

--- a/Tile_Structure/Tile.cpp
+++ b/Tile_Structure/Tile.cpp
@@ -537,3 +537,8 @@ std::vector<std::string> Tile::getOpenFaces()
 		openFaces.push_back("right");
 	return openFaces;
 }
+
+void Tile::placeMeeple(std::pair<int, int> location)
+{
+	innerBlocks[location.first][location.second].placeMeeple();
+}

--- a/Tile_Structure/Tile.h
+++ b/Tile_Structure/Tile.h
@@ -31,16 +31,28 @@ public:
 	bool hasInit() { return initialization; }
 
 	// Get the type of a face
-  	std::string getUpFaceType() { return up.getType(); }
-  	std::string getDownFaceType() { return down.getType(); }
-  	std::string getLeftFaceType() { return left.getType(); }
-  	std::string getRightFaceType() { return right.getType(); }
+  	std::string getUpFaceType() { return upFace.getType(); }
+  	std::string getDownFaceType() { return downFace.getType(); }
+  	std::string getLeftFaceType() { return leftFace.getType(); }
+  	std::string getRightFaceType() { return rightFace.getType(); }
 
-  	// Get the faces
-  	Face* getUpFace() { return &up; }
-  	Face* getDownFace() { return &down; }
-  	Face* getLeftFace() { return &left; }
-  	Face* getRightFace() { return &right; }
+  	// Get the inner faces
+  	Face* getUpFace() { return &upFace; }
+  	Face* getDownFace() { return &downFace; }
+  	Face* getLeftFace() { return &leftFace; }
+  	Face* getRightFace() { return &rightFace; }
+
+  	// Get the adjacent Tiles
+  	Tile* getUpTile() { return upTile; }
+  	Tile* getDownTile() { return downTile; }
+  	Tile* getLeftTile() { return leftTile; }
+  	Tile* getRightTile() { return rightTile; }
+
+  	// Used to set internal tile pointers to adjacent neighbors
+  	void setNeighborUpTile(Tile &tile);
+  	void setNeighborDownTile(Tile &tile);
+  	void setNeighborLeftTile(Tile &tile);
+  	void setNeighborRightTile(Tile &tile);
 
 	Block getCenter() { return innerBlocks[1][1]; }
 
@@ -61,7 +73,12 @@ private:
   	// Attribute to tell us if the tile is a skeleton board tile or an initialized game tile
   	bool initialization;
   	// The four faces of the tile which will contain all the types
-  	Face up, down, left, right;
+  	Face upFace, downFace, leftFace, rightFace;
+  	// Used for finding adjacent tiles when traversing the board
+  	Tile* upTile = NULL;
+  	Tile* downTile = NULL;
+  	Tile* leftTile = NULL;
+  	Tile* rightTile = NULL;
   	// 3x3 matrix of blocks in the tile
   	std::vector< std::vector<Block> > innerBlocks;
 

--- a/Tile_Structure/Tile.h
+++ b/Tile_Structure/Tile.h
@@ -15,6 +15,8 @@ public:
 	// Set a row of blocks for a tile
 	void setRow(int row, char type1, char type2, char type3);
 
+	void placeMeeple(std::pair<int, int> location);
+
 	// Rotate the tile and set all of the faces to the face that was -90 degrees of it.
 	void rotate();
 	// Function to check if a tile is connected on all 4 sides

--- a/UnitTester.cpp
+++ b/UnitTester.cpp
@@ -1,0 +1,296 @@
+#include "UnitTester.h"
+
+UnitTester::UnitTester() {}
+
+UnitTester::~UnitTester() {}
+
+std::vector<bool> UnitTester::createFace() {
+	// Vector to store results
+	std::vector<bool> results;
+	
+	// Test 0
+	try {
+		Face testFace;
+		results.push_back(true);
+	} catch (bool result) {
+		results.push_back(result);
+	}
+
+	// Test 1
+	try {
+		Face testFace(NULL, "Jungle", "Boar");
+		results.push_back(true);
+	} catch (bool result) {
+		results.push_back(false);
+	}
+
+	// Test 2
+	try {
+		Face testFace(NULL, NULL, NULL, NULL, "Lake", "Deer");
+		results.push_back(true);
+	} catch (bool result) {
+		results.push_back(false);
+	}
+
+	return results;
+}
+
+std::vector<bool> UnitTester::internalPointers() {
+	// Vector to store results
+	std::vector<bool> results;
+
+	// Create testFace and other faces
+	Face* left = new Face(NULL, "Lake", "None");
+	Face* right = new Face(NULL, "Jungle", "Boar");
+	Face* opposite = new Face(NULL, "Path", "Deer");
+	Face testFace(NULL, left, right, opposite, "Lake", "Deer");
+
+	// Conduct tests
+	if (testFace.getLeft()->getType() == "Lake" && !testFace.getLeft()->hasAnimal())
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	if (testFace.getRight()->getType() == "Jungle" && testFace.getRight()->hasAnimal())
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	if (testFace.getOpposite()->getType() == "Path" && testFace.getOpposite()->hasAnimal())
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	return results;
+}
+
+std::vector<bool> UnitTester::externalPointer() {
+	// Vector to store results
+	std::vector<bool> results;
+
+	// Create testFace
+	Face testFace(NULL, "Lake", "Deer");
+
+	// Conduct tests
+	if (testFace.getExternal() == NULL)
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	Face* externalFace = new Face(NULL, "Lake", "None");
+	testFace.setExternal(externalFace);
+
+	if (testFace.getExternal()->getType() == "Lake" && !testFace.getExternal()->hasAnimal())
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	return results;
+}
+
+std::vector<bool> UnitTester::createTile() {
+	// Vector to store results
+	std::vector<bool> results;
+	
+	// Test 0
+	Tile testTile0;
+	if (!testTile0.getDen())
+		results.push_back(true);
+	else
+		results.push_back(false);
+	
+	// Test 1
+	Face* testUp;
+	Face* testDown;
+	Face* testLeft;
+	Face* testRight;
+	Tile testTile1(testUp, testDown, testLeft, testRight, true, false);
+
+	if (testTile1.getDen())
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	return results;
+}
+
+std::vector<bool> UnitTester::rotateTest() {
+	// Vector to store results
+	std::vector<bool> results;
+
+	// Construct faces for tile
+	Face* up = new Face(NULL, "Lake", "Deer");
+	Face* down = new Face(NULL, "Lake", "None");
+	Face* left = new Face(NULL, "Jungle", "None");
+	Face* right = new Face(NULL, "Jungle", "None");
+	
+	up->setInternalPointer("o", down);
+	down->setInternalPointer("o", up);
+
+	// Create tile and rotate
+	Tile testTile(up, down, left, right, false, true);
+	testTile.rotate();
+
+	if (testTile.getUpFace()->getType() == "Jungle"   && 
+		testTile.getDownFace()->getType() == "Jungle" && 
+		testTile.getLeftFace()->getType() == "Lake"   && 
+		testTile.getRightFace()->getType() == "Lake")
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	testTile.rotate();
+	if (testTile.getUpFace()->getType() == "Lake"   	&& 
+		testTile.getDownFace()->getType() == "Lake" 	&& 
+		testTile.getLeftFace()->getType() == "Jungle"   && 
+		testTile.getRightFace()->getType() == "Jungle")
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	testTile.rotate();
+	if (testTile.getUpFace()->getType() == "Jungle"   &&
+		testTile.getDownFace()->getType() == "Jungle" && 
+		testTile.getLeftFace()->getType() == "Lake"   && 
+		testTile.getRightFace()->getType() == "Lake")
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	return results;
+}
+
+std::vector<bool> UnitTester::openFacesTest() {
+	// Vector to store results
+	std::vector<bool> results;
+
+	// Construct faces for tile
+	Face* up = new Face(NULL, "Lake", "Deer");
+	Face* down = new Face(NULL, "Lake", "None");
+	Face* left = new Face(NULL, "Jungle", "None");
+	Face* right = new Face(NULL, "Jungle", "None");
+	Face* external = new Face();
+	
+	up->setInternalPointer("o", down);
+	down->setInternalPointer("o", up);
+
+	// Create tile and get faces
+	Tile testTile(up, down, left, right, false, true);
+	std::vector<Face*> openFaces;
+	openFaces = testTile.getOpenFaces();
+
+	if (openFaces.size() == 4)
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	// Change external pointer
+	testTile.getUpFace()->setExternal(external);
+	openFaces.clear();
+	openFaces = testTile.getOpenFaces();
+
+	if (openFaces.size() == 3)
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	// Change external pointer
+	testTile.getLeftFace()->setExternal(external);
+	openFaces.clear();
+	openFaces = testTile.getOpenFaces();
+
+	if (openFaces.size() == 2)
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	return results;
+}
+
+std::vector<bool> UnitTester::connectedFacesTest() {
+	// Vector to store results
+	std::vector<bool> results;
+
+	// Construct faces for tile
+	Face* up = new Face(NULL, "Lake", "Deer");
+	Face* down = new Face(NULL, "Lake", "None");
+	Face* left = new Face(NULL, "Jungle", "None");
+	Face* right = new Face(NULL, "Jungle", "None");
+	Face* external = new Face();
+	
+	up->setInternalPointer("o", down);
+	down->setInternalPointer("o", up);
+
+	// Create tile and get faces
+	Tile testTile(up, down, left, right, false, true);
+	std::vector<Face*> connectedFaces;
+	connectedFaces = testTile.getConnected(testTile.getUpFace());
+
+	if (connectedFaces.size() == 1)
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	connectedFaces.clear();
+	connectedFaces = testTile.getConnected(testTile.getDownFace());
+	if (connectedFaces.size() == 1)
+		results.push_back(true);
+	else
+		results.push_back(false);
+
+	return results;
+}
+
+void UnitTester::printResults(std::vector<bool> &v) {
+	// Prints contents of vector
+	for (int i = 0; i < v.size(); i++) {
+		if (v[i] == true)
+			std::cout<<"Test "<<i<<": PASS"<<std::endl;
+		else
+			std::cout<<"Test "<<i<<": FAIL"<<std::endl;
+	}
+}
+
+void UnitTester::runTests() {
+	// Executes tests
+	std::vector<bool> myVector;
+	myVector = createFace();
+	std::cout<<"Conducting createFace tests..."<<std::endl;
+	printResults(myVector);
+
+	std::cout<<std::endl;
+	std::cout<<"Conducting externalPointer tests..."<<std::endl;
+	myVector.clear();
+	myVector = externalPointer();
+	printResults(myVector);
+
+	std::cout<<std::endl;
+	std::cout<<"Conducting internalPointers tests..."<<std::endl;
+	myVector.clear();
+	myVector = internalPointers();
+	printResults(myVector);
+
+	std::cout<<std::endl;
+	std::cout<<"Conducting createTile tests..."<<std::endl;
+	myVector.clear();
+	myVector = createTile();
+	printResults(myVector);
+
+	std::cout<<std::endl;
+	std::cout<<"Conducting rotateTile tests..."<<std::endl;
+	myVector.clear();
+	myVector = rotateTest();
+	printResults(myVector);
+
+	std::cout<<std::endl;
+	std::cout<<"Conducting getOpenFaces tests..."<<std::endl;
+	myVector.clear();
+	myVector = openFacesTest();
+	printResults(myVector);
+
+	std::cout<<std::endl;
+	std::cout<<"Conducting getConnectedFaces tests..."<<std::endl;
+	myVector.clear();
+	myVector = connectedFacesTest();
+	printResults(myVector);
+}

--- a/UnitTester.h
+++ b/UnitTester.h
@@ -1,0 +1,27 @@
+#include "Tile.h"
+#include "Face.h"
+
+class UnitTester {
+public:
+	// Constructor & Destructor 
+	UnitTester();
+	~UnitTester();
+
+	// Methods for Face
+	std::vector<bool> createFace();			// Tests constructors
+	std::vector<bool> internalPointers();	// Tests internal pointers
+	std::vector<bool> externalPointer();	// Tests external pointers
+
+	// Methods for Tile
+	std::vector<bool> createTile();			// Tests constructor 
+	std::vector<bool> rotateTest();
+	std::vector<bool> openFacesTest();
+	std::vector<bool> connectedFacesTest();
+
+	// Other Methods
+	void runTests();						// Executes tests
+	void printResults(std::vector<bool> &v);// Prints vector containing results
+
+private:
+	
+};

--- a/main.cpp
+++ b/main.cpp
@@ -92,17 +92,19 @@ void printStack(TileStack stack) //debugging
 int main() {
 	Board gameboard;
 	std::cout<<"in game"<<std::endl;
-	Tile tile1(8);
+	Tile tile1(21);
+	Tile tile2(8);
 	TileStack tStack;
 	tStack.shuffle();
 	Player p1;
 	Player p2;
 	std::cout<<"tile 1 up face is "<<tile1.getUpFace()->getType()<<std::endl;
 	gameboard.place_tile(std::pair<int, int>(72,72), tile1);
+	gameboard.place_tile(std::pair<int, int>(72,71), tile2);
 	// Game game1("123", p1, p2, tStack, tile1, std::pair<int,int> (72,72));
 	// game1.play();
 
-	Tile tile2(5);
+	// Tile tile2(5);
 	// gameboard.place_tile(std::pair<int,int>(71,72), tile2);
 	/*
 	Tile *tmpTile = new Tile(tStack.tiles[0].getNum());

--- a/main.cpp
+++ b/main.cpp
@@ -92,18 +92,18 @@ void printStack(TileStack stack) //debugging
 int main() {
 	Board gameboard;
 	std::cout<<"in game"<<std::endl;
-	Tile tile1(19);
+	Tile tile1(8);
 	TileStack tStack;
 	tStack.shuffle();
 	Player p1;
 	Player p2;
 	std::cout<<"tile 1 up face is "<<tile1.getUpFace()->getType()<<std::endl;
 	gameboard.place_tile(std::pair<int, int>(72,72), tile1);
-	Game game1("123", p1, p2, tStack, tile1, std::pair<int,int> (72,72));
+	// Game game1("123", p1, p2, tStack, tile1, std::pair<int,int> (72,72));
 	// game1.play();
 
 	Tile tile2(5);
-	gameboard.place_tile(std::pair<int,int>(71,72), tile2);
+	// gameboard.place_tile(std::pair<int,int>(71,72), tile2);
 	/*
 	Tile *tmpTile = new Tile(tStack.tiles[0].getNum());
 	gameboard.place_tile(std::pair<int,int>(72,71), *tmpTile);

--- a/main.cpp
+++ b/main.cpp
@@ -111,7 +111,7 @@ int main() {
 		std::cout<<i<<") "<<availableLocations[i].first<<' '<<availableLocations[i].second<<std::endl;
 	}
 	*/
-	// printBoard(game1.gameboard);
+	printBoard(game1.gameboard);
 
 	// Board gameBoard;
 	// gameBoard.place_tile(std::pair<int, int>(72, 50), tile1);

--- a/main.cpp
+++ b/main.cpp
@@ -94,13 +94,17 @@ int main() {
 	std::cout<<"in game"<<std::endl;
 	Tile tile1(21);
 	Tile tile2(8);
+	Tile tile3(20);
+	Tile tile4(9);
 	TileStack tStack;
 	tStack.shuffle();
 	Player p1;
 	Player p2;
 	std::cout<<"tile 1 up face is "<<tile1.getUpFace()->getType()<<std::endl;
-	gameboard.place_tile(std::pair<int, int>(72,72), tile1);
+	// gameboard.place_tile(std::pair<int, int>(72,72), tile1);
 	gameboard.place_tile(std::pair<int, int>(72,71), tile2);
+	// gameboard.place_tile(std::pair<int, int>(71,72), tile3);
+	gameboard.place_tile(std::pair<int, int>(71,71), tile4);
 	// Game game1("123", p1, p2, tStack, tile1, std::pair<int,int> (72,72));
 	// game1.play();
 

--- a/main.cpp
+++ b/main.cpp
@@ -100,7 +100,10 @@ int main() {
 	std::cout<<"tile 1 up face is "<<tile1.getUpFace()->getType()<<std::endl;
 	gameboard.place_tile(std::pair<int, int>(72,72), tile1);
 	Game game1("123", p1, p2, tStack, tile1, std::pair<int,int> (72,72));
-	game1.play();
+	// game1.play();
+
+	Tile tile2(5);
+	gameboard.place_tile(std::pair<int,int>(71,72), tile2);
 	/*
 	Tile *tmpTile = new Tile(tStack.tiles[0].getNum());
 	gameboard.place_tile(std::pair<int,int>(72,71), *tmpTile);
@@ -111,7 +114,7 @@ int main() {
 		std::cout<<i<<") "<<availableLocations[i].first<<' '<<availableLocations[i].second<<std::endl;
 	}
 	*/
-	printBoard(game1.gameboard);
+	// printBoard(game1.gameboard);
 
 	// Board gameBoard;
 	// gameBoard.place_tile(std::pair<int, int>(72, 50), tile1);

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 #this target will compile all files
 all: TigerZone
 
-TigerZone: main.o Game.o Board.o Player.o Meeple.o Farmer.o Monk.o TileStack.o Tile.o Face.o Block.o
-	g++ main.o Game.o Board.o Player.o Meeple.o Farmer.o Monk.o TileStack.o Tile.o Face.o Block.o -o tiger.out
+TigerZone: main.o Game.o Board.o Player.o Meeple.o Farmer.o Monk.o TileStack.o Tile.o Face.o Block.o Structure.o
+	g++ main.o Game.o Board.o Player.o Meeple.o Farmer.o Monk.o TileStack.o Tile.o Face.o Block.o Structure.o -o tiger.out
 
 main.o: main.cpp
 	g++ -std=c++11 -c main.cpp
@@ -36,6 +36,9 @@ Face.o: Tile_Structure/Face.cpp
 
 Block.o: Tile_Structure/Block.cpp
 	g++ -std=c++11 -c Tile_Structure/Block.cpp
+
+Structure.o: Tile_Structure/Structure.cpp
+	g++ -std=c++11 -c Tile_Structure/Structure.cpp
 
 clean:
 	rm -rf *o tiger.out


### PR DESCRIPTION
Since switching to the new architecture we lacked a way to get from one tile to another. Added 4 tile pointers within each tile object for up, down, left, and right. When we place a tile we will set these to the adjacent tiles so we may traverse the board when building/finding structures for meeple placement and checks.